### PR TITLE
Update board member list and details on about page

### DIFF
--- a/src/pages/about.astro
+++ b/src/pages/about.astro
@@ -61,46 +61,82 @@ import Section from '../components/Section.astro';
                 <tr>
                   <th class="px-6 py-4 text-left font-semibold">職位</th>
                   <th class="px-6 py-4 text-left font-semibold">姓名</th>
-                  <th class="px-6 py-4 text-left font-semibold">服務單位</th>
+                  <th class="px-6 py-4 text-left font-semibold">現職</th>
                   <th class="px-6 py-4 text-left font-semibold">專長領域</th>
                 </tr>
               </thead>
               <tbody class="divide-y divide-brand-border">
                 <tr class="hover:bg-brand-light transition-colors">
-                  <td class="px-6 py-4 font-semibold text-brand-primary">理事長</td>
-                  <td class="px-6 py-4 text-brand-secondary">張教授</td>
-                  <td class="px-6 py-4 text-brand-secondary">國立台灣大學資訊工程學系</td>
-                  <td class="px-6 py-4 text-brand-secondary">高效能運算、平行處理</td>
-                </tr>
-                <tr class="hover:bg-brand-light transition-colors">
-                  <td class="px-6 py-4 font-semibold text-brand-primary">副理事長</td>
-                  <td class="px-6 py-4 text-brand-secondary">李教授</td>
-                  <td class="px-6 py-4 text-brand-secondary">國立清華大學資訊工程學系</td>
-                  <td class="px-6 py-4 text-brand-secondary">分散式系統、雲端運算</td>
-                </tr>
-                <tr class="hover:bg-brand-light transition-colors">
-                  <td class="px-6 py-4 font-semibold text-brand-primary">秘書長</td>
-                  <td class="px-6 py-4 text-brand-secondary">王博士</td>
-                  <td class="px-6 py-4 text-brand-secondary">中央研究院資訊科學研究所</td>
-                  <td class="px-6 py-4 text-brand-secondary">機器學習、AI加速</td>
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">楊光磊</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立臺灣科技大學產學創新學院執行長</td>
+                  <td class="px-6 py-4 text-brand-secondary">半導體製程、企業數位化、職場教育</td>
                 </tr>
                 <tr class="hover:bg-brand-light transition-colors">
                   <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
-                  <td class="px-6 py-4 text-brand-secondary">陳教授</td>
-                  <td class="px-6 py-4 text-brand-secondary">國立成功大學電機工程學系</td>
-                  <td class="px-6 py-4 text-brand-secondary">IC設計、數位系統</td>
+                  <td class="px-6 py-4 text-brand-secondary">陳添福</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立陽明交通大學資訊工程學系教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">計算機結構、多核心系統、SoC 設計、嵌入式系統</td>
                 </tr>
                 <tr class="hover:bg-brand-light transition-colors">
                   <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
-                  <td class="px-6 py-4 text-brand-secondary">林博士</td>
-                  <td class="px-6 py-4 text-brand-secondary">國家高速網路與計算中心</td>
-                  <td class="px-6 py-4 text-brand-secondary">超級電腦、網格運算</td>
+                  <td class="px-6 py-4 text-brand-secondary">鄭良加</td>
+                  <td class="px-6 py-4 text-brand-secondary">工研院電光所組長</td>
+                  <td class="px-6 py-4 text-brand-secondary">半導體晶片設計</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">盧銘俊</td>
+                  <td class="px-6 py-4 text-brand-secondary">工研院電光所副所長</td>
+                  <td class="px-6 py-4 text-brand-secondary">半導體晶片設計</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">郭致宏</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立成功大學電機工程學系副教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">神經網路、深度學習演算法</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">許志仲</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立陽明交通大學智慧系統與應用研究所副教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">深度學習、多媒體資訊安全</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">張亞寧</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立成功大學敏求智慧運算學院助理教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">認知與大腦啟發式運算、跨語言的神經運算模型</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">陳坤志</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立陽明交通大學資訊工程學系副教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">超大型積體電路架構與電腦輔助系統設計、多核心系統晶片設計</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">理事</td>
+                  <td class="px-6 py-4 text-brand-secondary">周政毅</td>
+                  <td class="px-6 py-4 text-brand-secondary">個人開源貢獻者</td>
+                  <td class="px-6 py-4 text-brand-secondary">QEMU 系統模擬器</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">常務監事</td>
+                  <td class="px-6 py-4 text-brand-secondary">林偉棻</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立清華大學、國立陽明交通大學兼任教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">人工智慧晶片架構</td>
                 </tr>
                 <tr class="hover:bg-brand-light transition-colors">
                   <td class="px-6 py-4 font-semibold text-brand-primary">監事</td>
-                  <td class="px-6 py-4 text-brand-secondary">黃教授</td>
-                  <td class="px-6 py-4 text-brand-secondary">國立交通大學資訊工程學系</td>
-                  <td class="px-6 py-4 text-brand-secondary">嵌入式系統、物聯網</td>
+                  <td class="px-6 py-4 text-brand-secondary">謝明得</td>
+                  <td class="px-6 py-4 text-brand-secondary">國立成功大學電機工程學系教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">超大型積體電路設計與測試</td>
+                </tr>
+                <tr class="hover:bg-brand-light transition-colors">
+                  <td class="px-6 py-4 font-semibold text-brand-primary">監事</td>
+                  <td class="px-6 py-4 text-brand-secondary">張益興</td>
+                  <td class="px-6 py-4 text-brand-secondary">臺灣大學重點科技研究學院兼任教授</td>
+                  <td class="px-6 py-4 text-brand-secondary">半導體矽光子技術</td>
                 </tr>
               </tbody>
             </table>


### PR DESCRIPTION
Revised the table of board members to reflect updated names, positions, affiliations, and areas of expertise. Changed column header from '服務單位' to '現職' for clarity and replaced previous entries with new, more detailed information.